### PR TITLE
feat: option to include only specific events

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,13 +25,18 @@ export async function setupPlugin({ config, global }) {
         throw new RetryError('Service is down, retry later')
     }
 
+    const eventNames = (config.eventsToSend || '').split(',').filter(String)
+
     global.buffer = createBuffer({
         limit: (1 / 5) * 1024 * 1024, // 200kb
         timeoutSeconds: 5,
         onFlush: async (batch) => {
             console.log(`Flushing batch of length ${batch.length}`)
             for (const event of batch) {
-                await exportToCustomerio(event, global.customerioAuthHeader)
+                if (eventNames.length > 0 && !eventNames.includes(event.event)) { 
+                    continue;
+                }
+                 await exportToCustomerio(event, global.customerioAuthHeader)
             }
         }
     })

--- a/plugin.json
+++ b/plugin.json
@@ -22,6 +22,12 @@
             "default": "",
             "required": true,
             "secret": true
+        },
+        {
+            "key": "eventsToSend",
+            "name": "List of events to send to customerio. If not specified all events will be sent",
+            "type": "string",
+            "hint": "Comma separated list of events to include if specified"
         }
     ]
 }


### PR DESCRIPTION
I would like to introduce this because when we send everything to customerio it create a ton of unique customers due to the unique volume of the amount of people coming to our site.

this will allow us to only allow specific events to go to customerio that we will include for email campaigns