### PR TITLE
Create customers in Customer.io when identifying

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -34,6 +34,7 @@
             "name": "Send events from anonymous users to Customer.io",
             "type": "choice",
             "hint": "Customer.io pricing is based on the number of customers. This is an option to only send events from users that have been identified. Take into consideration that merging after identification won't work (as those previously anonymous events won't be there).",
+            "default": "Send all events",
             "choices": [
                 "Send all events",
                 "Only send events from users that have been identified"

--- a/plugin.json
+++ b/plugin.json
@@ -25,9 +25,19 @@
         },
         {
             "key": "eventsToSend",
-            "name": "List of events to send to customerio. If not specified all events will be sent",
+            "name": "List of events to send to Customer.io. If not specified all events will be sent",
             "type": "string",
             "hint": "Comma separated list of events to include if specified"
+        },
+        {
+            "key": "sendEventsFromAnonymousUsers",
+            "name": "Send events from anonymous users to Customer.io",
+            "type": "choice",
+            "hint": "Customer.io pricing is based on the number of customers. This is an option to only send events from users that have been identified. Take into consideration that merging after identification won't work (as those previously anonymous events won't be there).",
+            "choices": [
+                "Send all events",
+                "Only send events from users that have been identified"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Hey everyone 👋 

This is a big PR. When integrating PostHog, we decided to also enable the Customer.io plug-in and slowly start moving our email journeys there -- instead of SendGrid. 

While testing, I noticed a few things that could been improved: 
1. “Customers” are not created in Customer.io when they're identified in PostHog. This is an issue because just sending the `$identify` event isn't enough for Customer.io to actually create the customer with the correct attributes. 
2. Customer.io pricing is based on the number of customers. Currently _all_ events are being passed to it, including those from anonymous users. That creates anonymous users on their system -- unnecessarily adding them to the monthly 💸 . 

My proposed solutions, respectively:
1. If the event is `$identify`, create a customer in Customer.io -- instead of just forwarding the event. On that note, also pass the user's `email` (so that it can be used to create journeys, transactional messages etc).
2. A new option in the plug-in config, allowing the user to only send events from users that have been identified. 

Potential issues, respectivelly:
1. Nothing I can think of. 
2. In Customer.io, when a user finally identifies themselves there isn't a way to merge the pre-identification events with the post-identification ones. I've added that information in the key's hint.

On #2: When checking if the user's anonymous or not, I'm using a regular expression. This isn't _100%_ reliable*, but the alternative is calling PostHog's `GET /api/projects/:project_id/persons/:id` and checking the fields. This, in my opinion, will cause an unnecessary overhead to the buffer (and PostHog's servers). 

*If someone else is using the same uuid generator as PostHog (`^[\w]{14}-[\w]{14}-[\w]{8}-[\w]{6}-[\w]{14}$`), their users will always be considered to be anonymous. Since this seems to be a unique style of uuid, I think it's fine. 

--

Any feedback?

**Important**: I haven't tested this with a real PostHog instance -- just calling the methods locally with the correct params. I'm more than happy to pair with one of you and review/test this, if needed.