### PR TITLE
Reduce `storage.set` calls for customer.io plugin

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -176,7 +176,10 @@ async function syncCustomerMetadata(event: PluginEvent, storage: StorageExtensio
     if (email) {
         customerStatus.add('with_email')
     }
-    await storage.set(customerStatusKey, Array.from(customerStatus))
+
+    if (customerStatus.size > customerStatusArray.length) {
+        await storage.set(customerStatusKey, Array.from(customerStatus))
+    }
 
     return {
         status: customerStatus,


### PR DESCRIPTION
It's currently doing a set per event exported, even if the data hasn't
changed. Let's make this smarter.