### PR TITLE
Never send $create_alias events

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -126,7 +126,10 @@ export const exportEvents: Plugin<CustomerIoPluginInput>['exportEvents'] = async
     const nameFilteredEventsWithCustomers = filteredWithCustomers.filter(
         (event) => global.eventNames.length === 0 || global.eventNames.includes(event.event)
     )
-    const fullyFilteredEventsWithCustomers = nameFilteredEventsWithCustomers.filter(([, customer]) =>
+    const filterCreateAlias = filteredWithCustomers.filter(
+        (event) => event.event !== '$create_alias'
+    )
+    const fullyFilteredEventsWithCustomers = filterCreateAlias.filter(([, customer]) =>
         shouldCustomerBeTracked(customer, global.eventsConfig)
     )
 


### PR DESCRIPTION
`$create_alias` has no value, and if it gets called after a user was identified with an anonymous distinct_id, it might create a duplicate user in customer.io. See [this thread for more details (internal)](https://posthog.slack.com/archives/C03GMK07WLS/p1661528276275769?thread_ts=1661453859.924389&cid=C03GMK07WLS) for more details.