### PR TITLE
feat: identify by email

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "customerio-plugin",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Send event data and emails into Customer.io.",
     "main": "index.ts",
     "repository": {

--- a/plugin.json
+++ b/plugin.json
@@ -34,8 +34,9 @@
             "key": "identifyByEmail",
             "name": "Identify by email",
             "hint": "If enabled, the plugin will identify users by email instead of ID, whenever an email is available.",
-            "type": "boolean",
-            "default": false
+            "type": "choice",
+            "default": "No",
+            "choices": ["Yes", "No"]
         },
         {
             "key": "sendEventsFromAnonymousUsers",

--- a/plugin.json
+++ b/plugin.json
@@ -31,6 +31,13 @@
             "choices": ["track.customer.io", "track-eu.customer.io"]
         },
         {
+            "key": "identifyByEmail",
+            "name": "Identify by email",
+            "hint": "If enabled, the plugin will identify users by email instead of ID, whenever an email is available.",
+            "type": "boolean",
+            "default": false
+        },
+        {
             "key": "sendEventsFromAnonymousUsers",
             "name": "Filtering of Anonymous Users",
             "type": "choice",


### PR DESCRIPTION
- Adds a config option to identify users in customer.io by email rather than ID, if an email is present
- This fixes a problem that arises when using a customer.io workspace where people can be identified by `id` OR `email`, as if we identify customer.io people by `posthog_event.distinct_id`, we might try to update different people with the same email