### PR TITLE
filter customer attributes by max 1000 bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "customerio-plugin",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Send event data and emails into Customer.io.",
     "main": "index.ts",
     "repository": {


### PR DESCRIPTION
Customer.io requires customer attributes to be max 1000 bytes long. We don't currently do that, which means that some events fail to be imported.

With this PR, we filter out any attribute longer than 1000 bytes. 