### PR TITLE
fix: Send created_at in seconds

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -236,6 +236,12 @@ async function exportSingleEvent(
         identifier: event.distinct_id
     }
 
+    if ("created_at" in customerPayload) {
+        // Timestamp must be in seconds since UNIX epoch.
+        // See: https://customer.io/docs/journeys/faq-timestamps/.
+        customerPayload.created_at = Date.parse(customerPayload.created_at) / 1000
+    }
+
     let id = event.distinct_id
 
     if (customer.email) {


### PR DESCRIPTION
Customer.io plugin is an OnEvent app which should be running after the event has been ingested into ClickHouse. This means it receives `created_at` formatted for ClickHouse ingestion instead of as an integer Timestamp.

This PR parses the date input and turns it into an integer timestamp so that it can be ingested into Customer.io.

TODO: tests?