### PR TITLE
fix: Improve cleaning of provided event name allowlist

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -94,7 +94,12 @@ export const setupPlugin: Plugin<CustomerIoPluginInput>['setupPlugin'] = async (
         'base64'
     )
     global.authorizationHeader = `Basic ${customerioBase64AuthToken}`
-    global.eventNames = config.eventsToSend ? config.eventsToSend.split(',').filter(Boolean) : []
+    global.eventNames = config.eventsToSend
+        ? (config.eventsToSend as string)
+              .split(',')
+              .map((name) => name.trim())
+              .filter(Boolean)
+        : []
     global.eventsConfig =
         EVENTS_CONFIG_MAP[config.sendEventsFromAnonymousUsers || DEFAULT_SEND_EVENTS_FROM_ANONYMOUS_USERS]
     global.identifyByEmail = config.identifyByEmail === 'Yes'


### PR DESCRIPTION
Previously, if the allow list was specified as `a, b, c`, this would match on ` b` and ` c`, which is almost certainly not what anybody wants, and would erroneously filter _out_ `b` and `c`, rather than including them in the output set.

See also: https://posthoghelp.zendesk.com/agent/tickets/12549