### PR TITLE
Adding anonymous_id to customer and event payloads

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -205,7 +205,8 @@ async function exportSingleEvent(
     const customerPayload: Record<string, any> = {
         ...(event.$set || {}),
         _update: customer.existsAlready,
-        identifier: event.distinct_id
+        identifier: event.distinct_id,
+        anonymous_id: `anon_${event.distinct_id}`
     }
 
     if ("created_at" in customerPayload) {
@@ -234,6 +235,7 @@ async function exportSingleEvent(
         name: event.event,
         type: eventType,
         timestamp: eventTimestamp,
+        anonymous_id: `anon_${event.distinct_id}`,
         data: event.properties || {}
     })
 }


### PR DESCRIPTION
Per the CustomerIO documentation [here](https://customer.io/docs/journeys/anonymous-events/) I would like to track an `anonymous_id` for both identify and event calls. 

The goal is to enable "event merging" within the CutomerIO platform.